### PR TITLE
Add prettier plugin support

### DIFF
--- a/languages/java/config.toml
+++ b/languages/java/config.toml
@@ -8,3 +8,5 @@ brackets = [
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = false },
 ]
+prettier_parser_name = "java"
+prettier_plugins = ["prettier-plugin-java"]


### PR DESCRIPTION
This PR adds support for Prettier formatting for Java in Zed. 

Closes this issue in [zed-industries/zed #10241](https://github.com/zed-industries/zed/issues/10241).

Adds [prettier-plugin-java](https://github.com/jhipster/prettier-java) declaration to the `config.toml`